### PR TITLE
maioのバナー広告においてfailが発生したとき、クラッシュしてしまう問題を修正する。

### DIFF
--- a/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter.podspec
+++ b/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter.podspec
@@ -6,7 +6,7 @@
 #  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
 #
 
-adapter_version = "2.2.0.0.0"
+adapter_version = "2.2.0.0.1"
 
 Pod::Spec.new do |spec|
 

--- a/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter.m
+++ b/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter.m
@@ -1,7 +1,7 @@
 #import "AppLovinMaioMediationAdapter.h"
 #import <Maio/Maio-Swift.h>
 
-#define ADAPTER_VERSION @"2.2.0.0.0"
+#define ADAPTER_VERSION @"2.2.0.0.1"
 
 @interface AppLovinMaioMediationAdapterInterstitialAdDelegate : NSObject <MaioInterstitialLoadCallback, MaioInterstitialShowCallback>
 @property (nonatomic,   weak) AppLovinMaioMediationAdapter *parentAdapter;

--- a/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter.m
+++ b/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter.m
@@ -1,6 +1,10 @@
 #import "AppLovinMaioMediationAdapter.h"
 #import <Maio/Maio-Swift.h>
 
+// All AppLovin’s adapters use a five-number versioning scheme:
+//   The leftmost four numbers correspond to the network SDK version.
+//   The last number denotes the minor version number, which refers to the adapter release.
+// https://support.axon.ai/ja/max/demand-partners/building-a-custom-adapter
 #define ADAPTER_VERSION @"2.2.0.0.1"
 
 @interface AppLovinMaioMediationAdapterInterstitialAdDelegate : NSObject <MaioInterstitialLoadCallback, MaioInterstitialShowCallback>

--- a/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter.m
+++ b/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter/AppLovinMaioMediationAdapter.m
@@ -432,8 +432,9 @@
 
 - (void)didFailToLoad:(MaioBannerView *)ad errorCode:(NSInteger)errorCode
 {
-    [self.parentAdapter log: @"Banner ad failed to load with error: %@", errorCode];
-    [self.delegate didFailToLoadAdViewAdWithError:[AppLovinMaioMediationAdapter toMaxError:errorCode]];
+    MAAdapterError *adapterError = [AppLovinMaioMediationAdapter toMaxError:errorCode];
+    [self.parentAdapter log: @"Banner ad failed to load with error: %@", adapterError];
+    [self.delegate didFailToLoadAdViewAdWithError:adapterError];
 }
 
 - (void)didMakeImpression:(MaioBannerView *)ad
@@ -456,8 +457,9 @@
 
 - (void)didFailToShow:(MaioBannerView *)ad errorCode:(NSInteger)errorCode
 {
-    [self.parentAdapter log: @"Banner ad failed to show with error: %@", errorCode];
-    [self.delegate didFailToDisplayAdViewAdWithError:[AppLovinMaioMediationAdapter toMaxError:errorCode]];
+    MAAdapterError *adapterError = [AppLovinMaioMediationAdapter toMaxError:errorCode];
+    [self.parentAdapter log: @"Banner ad failed to show with error: %@", adapterError];
+    [self.delegate didFailToDisplayAdViewAdWithError:adapterError];
 }
 
 @end


### PR DESCRIPTION
Fix #5 

`-[AppLovinMaioMediationAdapterBannerAdDelegate didFailToLoad:errorCode:]` にて `-[ALMediationAdapter(Logging) log:]` に対しログメッセージを与えている。
このとき、 errorCode は `NSInteger` であるにも関わらずオブジェクト用のプレースホルダ `%@` を使っていたためクラッシュしてしまっていた。

RewardedやInterstitialと同様、`MAAdapterError*` として利用することで解決します。

また、`-[AppLovinMaioMediationAdapterBannerAdDelegate didFailToShow:errorCode:]` も同様に修正します。